### PR TITLE
Rename choria.use_srv_records -> choria.use_srv

### DIFF
--- a/environments/production/data/common.yaml
+++ b/environments/production/data/common.yaml
@@ -21,7 +21,7 @@ mcollective::site_policies:
     classes: "*"
 
 mcollective_choria::config:
-  use_srv_records: false
+  use_srv: false
 
 mcollective::plugin_classes:
   - mcollective_data_sysctl


### PR DESCRIPTION
Choria use `choria.use_srv` to check SRV records while MCollective used `choria.use_srv_records` for this purpose.  We are updating the mcorpc support gem to use a single setting `choria.use_srv` so update this repository accordingly.

On a side note, this repository contains a copy of the code from [the foreman puppet module](https://github.com/theforeman/puppet-puppet/) which [use `use_srv_records` for configuring Puppet SRV lookup](https://github.com/theforeman/puppet-puppet/search?q=use_srv_records).  Those are left untouched, only the Hiera configuration is updated.