### PR TITLE
fix: Make vagrant demo work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :update do
   rm_rf "environments/production/modules"
   mkdir_p "environments/production/modules"
 
-  sh "puppet module install --modulepath `pwd`/environments/production/modules puppetlabs/concat --version 6.4.0"
+  sh "puppet module install --modulepath `pwd`/environments/production/modules puppetlabs/concat --version 7.3.3"
 
   modules.each do |mod|
     sh "puppet module install --modulepath `pwd`/environments/production/modules %s" % mod

--- a/environments/production/modules/choria/data/os/Debian.yaml
+++ b/environments/production/modules/choria/data/os/Debian.yaml
@@ -1,2 +1,2 @@
 ---
-choria::version: "0.25.0"
+choria::version: "0.26.2"

--- a/environments/production/modules/choria/data/os/RedHat.yaml
+++ b/environments/production/modules/choria/data/os/RedHat.yaml
@@ -1,2 +1,2 @@
 ---
-choria::version: "0.25.0"
+choria::version: "0.26.2"


### PR DESCRIPTION
I found that the vagrant demo was not working, as the version of choria specified is not found in the choria repo.

This change fixes that issue.

I also took the liberty of upgrading the puppetlabs/concat module to the latest version, 7.3.3.