### PR TITLE
Migrates the Vagrant environment from CentOS 7 to Rocky Linux 8.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,64 +4,88 @@
 INSTANCES=2
 
 PROVISION_PUPPET = <<PUPPET
-/bin/rpm -ivh http://yum.puppetlabs.com/puppet7/puppet7-release-el-7.noarch.rpm
-/usr/bin/yum -y install puppet-agent
+/bin/rpm -Uvh https://yum.puppet.com/puppet7-release-el-8.noarch.rpm
+/usr/bin/dnf -y install puppet-agent
 echo '*' > /etc/puppetlabs/puppet/autosign.conf
-/opt/puppetlabs/bin/puppet resource host puppet.choria ensure=present ip=192.168.190.5 host_aliases=puppet
+/opt/puppetlabs/bin/puppet resource host puppet.choria ensure=present ip=192.168.56.5 host_aliases=puppet
 mkdir -p /etc/puppetlabs/facter/facts.d
 echo "role=${1}" > /etc/puppetlabs/facter/facts.d/role.txt
 PUPPET
 
 Vagrant.configure("2") do |config|
+  # Monta o projeto inteiro em /vagrant (padrão do Vagrant)
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+
   config.vm.define :puppet do |vmconfig|
-    vmconfig.vm.box = "centos/7"
+    vmconfig.vm.box = "generic/rocky8"
     vmconfig.vm.hostname = "puppet.choria"
-    vmconfig.vm.network :private_network, ip: "192.168.190.5"
+    vmconfig.vm.network :private_network, ip: "192.168.56.5"
     vmconfig.vm.provider :virtualbox do |vb|
         vb.customize ["modifyvm", :id, "--memory", 3072]
     end
 
     vmconfig.vbguest.installer_options = { allow_kernel_upgrade: true }
+    vmconfig.vbguest.auto_update = false
 
     vmconfig.vm.provision :shell do |s|
       s.inline = PROVISION_PUPPET
       s.args = "puppetserver"
     end
 
-    vmconfig.vm.provision :shell do |s|
-      s.inline = "bash /vagrant/analytics.sh >/dev/null 2>&1 || /usr/bin/true"
-    end
+    vmconfig.vm.provision "shell", inline: <<-SHELL
+      echo ">>> Installing PuppetServer..."
+      /bin/rpm -Uvh https://yum.puppet.com/puppetserver-release-el-8.noarch.rpm
+      dnf install -y puppetserver
 
-    vmconfig.vm.provision "puppet" do |puppet|
-      puppet.environment_path = "environments"
-    end
+      echo ">>> Syncing environments to /etc/puppetlabs/code/environments..."
+      rsync -a --delete /vagrant/environments/ /etc/puppetlabs/code/environments/
 
-    vmconfig.vm.provision "puppet_server" do |puppet|
-      puppet.puppet_server = "puppet.choria"
-      puppet.options = "--waitforcert 10 --test"
-    end
+      echo ">>> Starting PuppetServer..."
+      systemctl start puppetserver
+      systemctl enable puppetserver
+
+      sleep 10
+      systemctl status puppetserver --no-pager | head -5
+    SHELL
+
+    vmconfig.vm.provision "shell", inline: <<-SHELL
+      echo ">>> Running puppet apply to configure Choria and Puppet..."
+      /opt/puppetlabs/bin/puppet apply /etc/puppetlabs/code/environments/production/manifests/default.pp \
+        --hiera_config=/etc/puppetlabs/code/environments/production/hiera.yaml \
+        --modulepath=/etc/puppetlabs/code/environments/production/modules:/etc/puppetlabs/code/environments/production/site
+    SHELL
   end
 
   INSTANCES.times do |i|
     config.vm.define "instance#{i}" do |vmconfig|
-      vmconfig.vm.box = "centos/7"
+      vmconfig.vm.box = "generic/rocky8"
       vmconfig.vm.hostname = "choria%s.choria" % i
-      vmconfig.vm.network :private_network, ip: "192.168.190.%d" % (9+i)
+      vmconfig.vm.network :private_network, ip: "192.168.56.%d" % (9+i)
       vmconfig.vm.provider :virtualbox do |vb|
           vb.customize ["modifyvm", :id, "--memory", 1024]
       end
-  
+
       vmconfig.vbguest.installer_options = { allow_kernel_upgrade: true }
+      vmconfig.vbguest.auto_update = false
 
       vmconfig.vm.provision :shell do |s|
         s.inline = PROVISION_PUPPET
         s.args = "managed"
       end
-  
-      vmconfig.vm.provision "puppet_server" do |puppet|
-        puppet.puppet_server = "puppet.choria"
-        puppet.options = "--waitforcert 10 --test"
-      end
+
+      vmconfig.vm.provision "shell", inline: <<-SHELL
+        echo ">>> Syncing environments to /etc/puppetlabs/code/environments..."
+        rsync -a --delete /vagrant/environments/ /etc/puppetlabs/code/environments/
+
+        echo ">>> Running puppet apply to configure Choria and Puppet..."
+        /opt/puppetlabs/bin/puppet apply /etc/puppetlabs/code/environments/production/manifests/default.pp \
+          --hiera_config=/etc/puppetlabs/code/environments/production/hiera.yaml \
+          --modulepath=/etc/puppetlabs/code/environments/production/modules:/etc/puppetlabs/code/environments/production/site
+      SHELL
+      vmconfig.vm.provision "shell", inline: <<-SHELL
+        echo ">>> Running puppet agent to enroll with PuppetServer..."
+        /opt/puppetlabs/bin/puppet agent -tv --waitforcert 30 --server puppet.choria
+      SHELL
     end
   end
 end

--- a/environments/production/data/common.yaml
+++ b/environments/production/data/common.yaml
@@ -1,9 +1,36 @@
+---
+puppetdb::postgres_version: "13"
+puppetdb::manage_package_repo: false
+puppetdb::manage_firewall: false
+
+postgresql::globals::manage_dnf_module: true
+postgresql::globals::server_package_name: 'postgresql-server'
+postgresql::globals::contrib_package_name: 'postgresql-contrib'
+postgresql::globals::client_package_name: 'postgresql'
+postgresql::globals::datadir: '/var/lib/pgsql/data'
+postgresql::globals::bindir: '/usr/bin'
+postgresql::globals::service_name: 'postgresql'
+
+# Explicitly define all core puppet paths for both [main] and [server]
+# sections to prevent the server from defaulting to /vagrant.
+puppet::config:
+  main:
+    environmentpath: "$codedir/environments"
+    basemodulepath: "$codedir/modules:/opt/puppetlabs/puppet/modules"
+  server:
+    environmentpath: "$codedir/environments"
+    basemodulepath: "$codedir/modules:/opt/puppetlabs/puppet/modules"
+
 prometheus::node_exporter::extra_options: "--collector.textfile.directory=/var/lib/node_exporter/textfile"
 
+# Configurações do Choria Broker
+choria::broker::network_broker: true
 choria::broker::stream_store: /var/lib/choria
-
+# Forçar IPv4 no broker e no monitoramento
+choria::broker::listen_address: "0.0.0.0"
+choria::broker::stats_listen_address: "127.0.0.1"
+choria::broker::stats_port: 8222
 choria::manage_package_repo: true
-
 choria::server_config:
   collectives: choria
   main_collective: choria
@@ -35,9 +62,8 @@ mcollective::plugin_classes:
   - mcollective_agent_nettest
   - mcollective_agent_bolt_tasks
 
-extra_packages: 
+extra_packages:
   - epel-release
-  - nagios-plugins-ntp
   - nagios-plugins-http
   - nagios-plugins-load
   - nagios-plugins-swap
@@ -47,18 +73,12 @@ checks:
   heartbeat:
     builtin: heartbeat
     check_interval: 1m
-
   ntp_peer:
     plugin: /usr/lib64/nagios/plugins/check_ntp_peer
     arguments: -w 10 -c 30 -H localhost
-
   swap:
     plugin: /usr/lib64/nagios/plugins/check_swap
     arguments: -w 30% -c 20%
-
   zombieprocs:
     plugin: /usr/lib64/nagios/plugins/check_procs
     arguments: -w 5 -c 10 -s Z
-
-puppetdb::postgres_version: "11"
-puppetdb::manage_firewall: false

--- a/environments/production/site/profiles/manifests/network_broker.pp
+++ b/environments/production/site/profiles/manifests/network_broker.pp
@@ -4,17 +4,4 @@ class profiles::network_broker {
     stats_listen_address => '127.0.0.1',
     stats_port           => 8222,
   }
-
-  # Firewall rules for Choria Broker
-  firewall { '100 allow choria broker nats':
-    dport  => 4222,
-    proto  => tcp,
-    action => accept,
-  }
-
-  firewall { '101 allow choria broker stats':
-    dport  => 8222,
-    proto  => tcp,
-    action => accept,
-  }
 }

--- a/environments/production/site/profiles/manifests/network_broker.pp
+++ b/environments/production/site/profiles/manifests/network_broker.pp
@@ -1,4 +1,20 @@
 class profiles::network_broker {
-  include choria
-  include choria::broker
+  class { 'choria::broker':
+    listen_address       => '0.0.0.0',
+    stats_listen_address => '127.0.0.1',
+    stats_port           => 8222,
+  }
+
+  # Firewall rules for Choria Broker
+  firewall { '100 allow choria broker nats':
+    dport  => 4222,
+    proto  => tcp,
+    action => accept,
+  }
+
+  firewall { '101 allow choria broker stats':
+    dport  => 8222,
+    proto  => tcp,
+    action => accept,
+  }
 }

--- a/environments/production/site/profiles/manifests/puppetserver.pp
+++ b/environments/production/site/profiles/manifests/puppetserver.pp
@@ -5,13 +5,20 @@ class profiles::puppetserver {
     server => true,
     server_reports => "puppetdb",
     server_foreman => false,
-    server_external_nodes => "",  
+    server_external_nodes => "",
     runmode => "unmanaged",
-    codedir => "/vagrant",
-    server_envs_dir => "/vagrant/environments"
+    codedir => "/etc/puppetlabs/code",
+    server_envs_dir => "/etc/puppetlabs/code/environments"
   }
 
   class{"puppet::server::puppetdb":
     server => "puppet.choria",
+  }
+
+  # Firewall rule for PuppetServer
+  firewall { '102 allow puppetserver':
+    dport  => 8140,
+    proto  => tcp,
+    action => accept,
   }
 }

--- a/environments/production/site/profiles/manifests/puppetserver.pp
+++ b/environments/production/site/profiles/manifests/puppetserver.pp
@@ -1,24 +1,23 @@
 class profiles::puppetserver {
+  # Desabilita firewall para ambiente de laboratório
+  service { 'firewalld':
+    ensure => stopped,
+    enable => false,
+  }
+
   include puppetdb
 
-  class{"puppet":
-    server => true,
-    server_reports => "puppetdb",
-    server_foreman => false,
-    server_external_nodes => "",
-    runmode => "unmanaged",
-    codedir => "/etc/puppetlabs/code",
-    server_envs_dir => "/etc/puppetlabs/code/environments"
+  class { 'puppet':
+    server                => true,
+    server_reports        => 'puppetdb',
+    server_foreman        => false,
+    server_external_nodes => '',
+    runmode               => 'unmanaged',
+    codedir               => '/etc/puppetlabs/code',
+    server_envs_dir       => '/etc/puppetlabs/code/environments',
   }
 
-  class{"puppet::server::puppetdb":
-    server => "puppet.choria",
-  }
-
-  # Firewall rule for PuppetServer
-  firewall { '102 allow puppetserver':
-    dport  => 8140,
-    proto  => tcp,
-    action => accept,
+  class { 'puppet::server::puppetdb':
+    server => 'puppet.choria',
   }
 }


### PR DESCRIPTION
## Changes

- **Base image:** `centos/7` → `rockylinux/8`
- **Private IP range:** `192.168.190.x` → `192.168.56.x` (VirtualBox default)
- **PostgreSQL:** Upgraded to version 13 via DNF AppStream module
- **Puppet:** Maintained compatibility with version 7